### PR TITLE
Logging with Invalid Handle

### DIFF
--- a/Confluent.Kafka.DependencyInjection/Logging/KafkaLogState.cs
+++ b/Confluent.Kafka.DependencyInjection/Logging/KafkaLogState.cs
@@ -7,6 +7,8 @@ namespace Confluent.Kafka.DependencyInjection.Logging
 {
     readonly struct KafkaLogState : IReadOnlyList<KeyValuePair<string, object?>>
     {
+        private const string DefaultName = "Unknown";
+
         readonly IClient client;
         readonly object? payload;
 
@@ -24,7 +26,7 @@ namespace Confluent.Kafka.DependencyInjection.Logging
             {
                 return index switch
                 {
-                    0 => new("KafkaClient", client.Name),
+                    0 => new("KafkaClient", GetClientName()),
                     1 => new("{OriginalMessage}", payload),
                     _ => throw new ArgumentOutOfRangeException(nameof(index)),
                 };
@@ -46,7 +48,11 @@ namespace Confluent.Kafka.DependencyInjection.Logging
 
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", client.Name, payload);
+            return string.Format(CultureInfo.InvariantCulture, "[{0}] {1}", GetClientName(), payload);
         }
+
+        private string GetClientName() => client.Handle is null || client.Handle.IsInvalid
+            ? DefaultName
+            : client.Name;
     }
 }


### PR DESCRIPTION
Update logging to handle cases where client does not have a valid handle. This happens when the application DI container is setup via `AddKafkaClient` and the dictionary contains both consumer and producer configuration values. When constructing a `Consumer`, the underlying kafka library logs encountering a producer configuration value. Same thing occurs when constructing a `Producer`, regarding consumer configuration values. 