### PR TITLE
Inject builders (take 2)

### DIFF
--- a/Confluent.Kafka.DependencyInjection/Builders/ConsumerAdapter.cs
+++ b/Confluent.Kafka.DependencyInjection/Builders/ConsumerAdapter.cs
@@ -12,55 +12,58 @@ using System.Linq;
 
 sealed class ConsumerAdapter<TKey, TValue> : ConsumerBuilder<TKey, TValue>
 {
+    readonly IServiceProvider services;
     readonly IDisposable? scope;
 
     public ConsumerAdapter(IServiceScopeFactory scopes, ConfigWrapper config)
-        : this(config.Values, scopes.CreateScope(), dispose: true)
+        : this(scopes, config.Values)
     {
     }
 
-    internal ConsumerAdapter(
-        IEnumerable<KeyValuePair<string, string>> config,
-        IServiceScope scope,
-        bool dispose)
+    internal ConsumerAdapter(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
         : base(config)
     {
-        ErrorHandler = scope.ServiceProvider.GetServices<IErrorHandler>()
-            .Aggregate(default(Action<IClient, Error>), (x, y) => x + y.OnError);
+        IServiceScope scope;
+        this.scope = scope = scopes.CreateScope();
+        this.services = scope.ServiceProvider;
+    }
 
-        StatisticsHandler = scope.ServiceProvider.GetServices<IStatisticsHandler>()
-            .Aggregate(default(Action<IClient, string>), (x, y) => x + y.OnStatistics);
-
-        LogHandler = scope.ServiceProvider.GetServices<ILogHandler>()
-            .Aggregate(default(Action<IClient, LogMessage>), (x, y) => x + y.OnLog);
-
-        PartitionsAssignedHandler = scope.ServiceProvider.GetServices<IPartitionsAssignedHandler>()
-            .Aggregate(
-                default(Func<IClient, IEnumerable<TopicPartition>, IEnumerable<TopicPartitionOffset>>),
-                (x, y) => x + y.OnPartitionsAssigned);
-
-        PartitionsRevokedHandler = scope.ServiceProvider.GetServices<IPartitionsRevokedHandler>()
-            .Aggregate(
-                default(Func<IClient, IEnumerable<TopicPartitionOffset>, IEnumerable<TopicPartitionOffset>>),
-                (x, y) => x + y.OnPartitionsRevoked);
-
-        OffsetsCommittedHandler = scope.ServiceProvider.GetServices<IOffsetsCommittedHandler>()
-            .Aggregate(default(Action<IClient, CommittedOffsets>), (x, y) => x + y.OnOffsetsCommitted);
-
-        KeyDeserializer = scope.ServiceProvider.GetService<IDeserializer<TKey>>() ??
-            scope.ServiceProvider.GetService<IAsyncDeserializer<TKey>>()?.AsSyncOverAsync();
-
-        ValueDeserializer = scope.ServiceProvider.GetService<IDeserializer<TValue>>() ??
-            scope.ServiceProvider.GetService<IAsyncDeserializer<TValue>>()?.AsSyncOverAsync();
-
-        if (dispose)
-        {
-            this.scope = scope;
-        }
+    internal ConsumerAdapter(IServiceProvider services, IEnumerable<KeyValuePair<string, string>> config)
+        : base(config)
+    {
+        this.services = services;
     }
 
     public override IConsumer<TKey, TValue> Build()
     {
+        ErrorHandler ??= services.GetServices<IErrorHandler>()
+            .Aggregate(default(Action<IClient, Error>), (x, y) => x + y.OnError);
+
+        StatisticsHandler ??= services.GetServices<IStatisticsHandler>()
+            .Aggregate(default(Action<IClient, string>), (x, y) => x + y.OnStatistics);
+
+        LogHandler ??= services.GetServices<ILogHandler>()
+            .Aggregate(default(Action<IClient, LogMessage>), (x, y) => x + y.OnLog);
+
+        PartitionsAssignedHandler ??= services.GetServices<IPartitionsAssignedHandler>()
+            .Aggregate(
+                default(Func<IClient, IEnumerable<TopicPartition>, IEnumerable<TopicPartitionOffset>>),
+                (x, y) => x + y.OnPartitionsAssigned);
+
+        PartitionsRevokedHandler ??= services.GetServices<IPartitionsRevokedHandler>()
+            .Aggregate(
+                default(Func<IClient, IEnumerable<TopicPartitionOffset>, IEnumerable<TopicPartitionOffset>>),
+                (x, y) => x + y.OnPartitionsRevoked);
+
+        OffsetsCommittedHandler ??= services.GetServices<IOffsetsCommittedHandler>()
+            .Aggregate(default(Action<IClient, CommittedOffsets>), (x, y) => x + y.OnOffsetsCommitted);
+
+        KeyDeserializer ??= services.GetService<IDeserializer<TKey>>() ??
+            services.GetService<IAsyncDeserializer<TKey>>()?.AsSyncOverAsync();
+
+        ValueDeserializer ??= services.GetService<IDeserializer<TValue>>() ??
+            services.GetService<IAsyncDeserializer<TValue>>()?.AsSyncOverAsync();
+
         var consumer = base.Build();
         return scope != null ? new ScopedConsumer<TKey, TValue>(consumer, scope) : consumer;
     }

--- a/Confluent.Kafka.DependencyInjection/Clients/ConfigWrapper.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ConfigWrapper.cs
@@ -1,4 +1,4 @@
-namespace Confluent.Kafka.DependencyInjection.Builders;
+namespace Confluent.Kafka.DependencyInjection.Clients;
 
 using System.Collections.Generic;
 

--- a/Confluent.Kafka.DependencyInjection/Clients/DIConsumerBuilder.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/DIConsumerBuilder.cs
@@ -1,4 +1,4 @@
-namespace Confluent.Kafka.DependencyInjection.Builders;
+namespace Confluent.Kafka.DependencyInjection.Clients;
 
 using Confluent.Kafka.DependencyInjection.Handlers;
 using Confluent.Kafka.SyncOverAsync;
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-sealed class ConsumerAdapter<TKey, TValue> : ConsumerBuilder<TKey, TValue>
+sealed class DIConsumerBuilder<TKey, TValue> : ConsumerBuilder<TKey, TValue>
 {
     readonly IEnumerable<IErrorHandler> errorHandlers;
     readonly IEnumerable<IStatisticsHandler> statisticsHandlers;
@@ -20,7 +20,7 @@ sealed class ConsumerAdapter<TKey, TValue> : ConsumerBuilder<TKey, TValue>
     readonly IAsyncDeserializer<TKey>? asyncKeyDeserializer;
     readonly IAsyncDeserializer<TValue>? asyncValueDeserializer;
 
-    public ConsumerAdapter(
+    public DIConsumerBuilder(
         ConfigWrapper config,
         IEnumerable<IErrorHandler> errorHandlers,
         IEnumerable<IStatisticsHandler> statisticsHandlers,

--- a/Confluent.Kafka.DependencyInjection/Clients/DIProducerBuilder.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/DIProducerBuilder.cs
@@ -1,4 +1,4 @@
-namespace Confluent.Kafka.DependencyInjection.Builders;
+namespace Confluent.Kafka.DependencyInjection.Clients;
 
 using Confluent.Kafka.DependencyInjection.Handlers;
 
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-sealed class ProducerAdapter<TKey, TValue> : ProducerBuilder<TKey, TValue>
+sealed class DIProducerBuilder<TKey, TValue> : ProducerBuilder<TKey, TValue>
 {
     readonly IEnumerable<IErrorHandler> errorHandlers;
     readonly IEnumerable<IStatisticsHandler> statisticsHandlers;
@@ -16,7 +16,7 @@ sealed class ProducerAdapter<TKey, TValue> : ProducerBuilder<TKey, TValue>
     readonly IAsyncSerializer<TKey>? asyncKeySerializer;
     readonly IAsyncSerializer<TValue>? asyncValueSerializer;
 
-    public ProducerAdapter(
+    public DIProducerBuilder(
         ConfigWrapper config,
         IEnumerable<IErrorHandler> errorHandlers,
         IEnumerable<IStatisticsHandler> statisticsHandlers,

--- a/Confluent.Kafka.DependencyInjection/Clients/ScopedConsumer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ScopedConsumer.cs
@@ -1,6 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection.Clients;
 
-using Confluent.Kafka.DependencyInjection.Builders;
 using Confluent.Kafka.DependencyInjection.Handlers;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -38,7 +37,7 @@ class ScopedConsumer<TKey, TValue> : IConsumer<TKey, TValue>
         IEnumerable<KeyValuePair<string, string>>? config)
     {
         return config != null
-            ? new ConsumerAdapter<TKey, TValue>(
+            ? new DIConsumerBuilder<TKey, TValue>(
                 new(config),
                 services.GetServices<IErrorHandler>(),
                 services.GetServices<IStatisticsHandler>(),

--- a/Confluent.Kafka.DependencyInjection/Clients/ScopedProducer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ScopedProducer.cs
@@ -1,6 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection.Clients;
 
-using Confluent.Kafka.DependencyInjection.Builders;
 using Confluent.Kafka.DependencyInjection.Handlers;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +30,7 @@ class ScopedProducer<TKey, TValue> : IProducer<TKey, TValue>
         IEnumerable<KeyValuePair<string, string>>? config)
     {
        return config != null
-            ? new ProducerAdapter<TKey, TValue>(
+            ? new DIProducerBuilder<TKey, TValue>(
                 new(config),
                 services.GetServices<IErrorHandler>(),
                 services.GetServices<IStatisticsHandler>(),

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
@@ -11,7 +11,7 @@ using System.Linq;
 sealed class ServiceConsumer<TReceiver, TKey, TValue> : ServiceConsumer<TKey, TValue>
 {
     public ServiceConsumer(IServiceScopeFactory scopes, ConfigWrapper<TReceiver> config, ConfigWrapper? global = null)
-        : base(global?.Values.Concat(config.Values) ?? config.Values, scopes.CreateScope())
+        : base(scopes, global?.Values.Concat(config.Values) ?? config.Values)
     {
     }
 }
@@ -21,12 +21,17 @@ class ServiceConsumer<TKey, TValue> : ScopedConsumer<TKey, TValue>
     bool closed;
 
     public ServiceConsumer(IServiceScopeFactory scopes, ConfigWrapper config)
-        : this(config.Values, scopes.CreateScope())
+        : this(scopes, config.Values)
     {
     }
 
-    protected ServiceConsumer(IEnumerable<KeyValuePair<string, string>> config, IServiceScope scope)
-        : base(new ConsumerAdapter<TKey, TValue>(config, scope, dispose: false).Build(), scope)
+    internal ServiceConsumer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
+        : this(scopes.CreateScope(), config)
+    {
+    }
+
+    ServiceConsumer(IServiceScope scope, IEnumerable<KeyValuePair<string, string>> config)
+        : base(new ConsumerAdapter<TKey, TValue>(scope.ServiceProvider, config).Build(), scope)
     {
     }
 

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
@@ -1,7 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection.Clients;
 
-using Confluent.Kafka.DependencyInjection.Builders;
-
 using Microsoft.Extensions.DependencyInjection;
 
 using System.Collections.Generic;

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceConsumer.cs
@@ -21,17 +21,12 @@ class ServiceConsumer<TKey, TValue> : ScopedConsumer<TKey, TValue>
     bool closed;
 
     public ServiceConsumer(IServiceScopeFactory scopes, ConfigWrapper config)
-        : this(scopes, config.Values)
+        : base(scopes, config.Values)
     {
     }
 
-    internal ServiceConsumer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
-        : this(scopes.CreateScope(), config)
-    {
-    }
-
-    ServiceConsumer(IServiceScope scope, IEnumerable<KeyValuePair<string, string>> config)
-        : base(new ConsumerAdapter<TKey, TValue>(scope.ServiceProvider, config).Build(), scope)
+    protected ServiceConsumer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
+        : base(scopes, config)
     {
     }
 

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
@@ -23,13 +23,8 @@ class ServiceProducer<TKey, TValue> : ScopedProducer<TKey, TValue>
     {
     }
 
-    internal ServiceProducer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
-        : this(scopes.CreateScope(), config)
-    {
-    }
-
-    ServiceProducer(IServiceScope scope, IEnumerable<KeyValuePair<string, string>> config)
-        : base(new ProducerAdapter<TKey, TValue>(scope.ServiceProvider, config).Build(), scope)
+    protected ServiceProducer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
+        : base(scopes, config)
     {
     }
 }

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
@@ -11,7 +11,7 @@ using System.Linq;
 sealed class ServiceProducer<TReceiver, TKey, TValue> : ServiceProducer<TKey, TValue>
 {
     public ServiceProducer(IServiceScopeFactory scopes, ConfigWrapper<TReceiver> config, ConfigWrapper? global = null)
-        : base(global?.Values.Concat(config.Values) ?? config.Values, scopes.CreateScope())
+        : base(scopes, global?.Values.Concat(config.Values) ?? config.Values)
     {
     }
 }
@@ -19,12 +19,17 @@ sealed class ServiceProducer<TReceiver, TKey, TValue> : ServiceProducer<TKey, TV
 class ServiceProducer<TKey, TValue> : ScopedProducer<TKey, TValue>
 {
     public ServiceProducer(IServiceScopeFactory scopes, ConfigWrapper config)
-        : this(config.Values, scopes.CreateScope())
+        : this(scopes, config.Values)
     {
     }
 
-    protected ServiceProducer(IEnumerable<KeyValuePair<string, string>> config, IServiceScope scope)
-        : base(new ProducerAdapter<TKey, TValue>(config, scope, dispose: false).Build(), scope)
+    internal ServiceProducer(IServiceScopeFactory scopes, IEnumerable<KeyValuePair<string, string>> config)
+        : this(scopes.CreateScope(), config)
+    {
+    }
+
+    ServiceProducer(IServiceScope scope, IEnumerable<KeyValuePair<string, string>> config)
+        : base(new ProducerAdapter<TKey, TValue>(scope.ServiceProvider, config).Build(), scope)
     {
     }
 }

--- a/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
+++ b/Confluent.Kafka.DependencyInjection/Clients/ServiceProducer.cs
@@ -1,7 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection.Clients;
 
-using Confluent.Kafka.DependencyInjection.Builders;
-
 using Microsoft.Extensions.DependencyInjection;
 
 using System.Collections.Generic;

--- a/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
+++ b/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
@@ -24,13 +24,13 @@ sealed class KafkaFactory : IKafkaFactory
     public IProducer<TKey, TValue> CreateProducer<TKey, TValue>(
         IEnumerable<KeyValuePair<string, string>>? configuration = null)
     {
-        return new ProducerAdapter<TKey, TValue>(Merge(configuration), scopes.CreateScope(), dispose: true).Build();
+        return new ProducerAdapter<TKey, TValue>(scopes, Merge(configuration)).Build();
     }
 
     public IConsumer<TKey, TValue> CreateConsumer<TKey, TValue>(
         IEnumerable<KeyValuePair<string, string>>? configuration = null)
     {
-        return new ConsumerAdapter<TKey, TValue>(Merge(configuration), scopes.CreateScope(), dispose: true).Build();
+        return new ConsumerAdapter<TKey, TValue>(scopes, Merge(configuration)).Build();
     }
 
     IEnumerable<KeyValuePair<string, string>> Merge(IEnumerable<KeyValuePair<string, string>>? overrides)

--- a/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
+++ b/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
@@ -5,7 +5,6 @@ using Confluent.Kafka.DependencyInjection.Clients;
 
 using Microsoft.Extensions.DependencyInjection;
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -24,19 +23,19 @@ sealed class KafkaFactory : IKafkaFactory
     public IProducer<TKey, TValue> CreateProducer<TKey, TValue>(
         IEnumerable<KeyValuePair<string, string>>? configuration = null)
     {
-        return new ProducerAdapter<TKey, TValue>(scopes, Merge(configuration)).Build();
+        return new ScopedProducer<TKey, TValue>(scopes, Merge(configuration));
     }
 
     public IConsumer<TKey, TValue> CreateConsumer<TKey, TValue>(
         IEnumerable<KeyValuePair<string, string>>? configuration = null)
     {
-        return new ConsumerAdapter<TKey, TValue>(scopes, Merge(configuration)).Build();
+        return new ScopedConsumer<TKey, TValue>(scopes, Merge(configuration));
     }
 
-    IEnumerable<KeyValuePair<string, string>> Merge(IEnumerable<KeyValuePair<string, string>>? overrides)
+    IEnumerable<KeyValuePair<string, string>>? Merge(IEnumerable<KeyValuePair<string, string>>? configuration)
     {
-        return overrides != null
-            ? config?.Values.Concat(overrides) ?? overrides
-            : config?.Values ?? throw new InvalidOperationException("Configuration is required.");
+        return configuration != null
+            ? this.config?.Values.Concat(configuration) ?? configuration
+            : null;
     }
 }

--- a/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
+++ b/Confluent.Kafka.DependencyInjection/KafkaFactory.cs
@@ -1,6 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection;
 
-using Confluent.Kafka.DependencyInjection.Builders;
 using Confluent.Kafka.DependencyInjection.Clients;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/Confluent.Kafka.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Confluent.Kafka.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 namespace Confluent.Kafka.DependencyInjection;
 
-using Confluent.Kafka.DependencyInjection.Builders;
 using Confluent.Kafka.DependencyInjection.Clients;
 using Confluent.Kafka.DependencyInjection.Handlers;
 using Confluent.Kafka.DependencyInjection.Handlers.Default;
@@ -124,8 +123,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IOffsetsCommittedHandler, CommitHandler>();
 
         // These must be transient to consume scoped handlers.
-        services.TryAddTransient(typeof(ProducerBuilder<,>), typeof(ProducerAdapter<,>));
-        services.TryAddTransient(typeof(ConsumerBuilder<,>), typeof(ConsumerAdapter<,>));
+        services.TryAddTransient(typeof(ProducerBuilder<,>), typeof(DIProducerBuilder<,>));
+        services.TryAddTransient(typeof(ConsumerBuilder<,>), typeof(DIConsumerBuilder<,>));
 
         return services;
     }


### PR DESCRIPTION
While each producer/consumer is resolved within its own scope, there are situations where it may be advantageous to resolve a builder from within a custom scope. This will allow a caller to modify state on some scoped service (e.g. a handler), and subsequently resolve a builder utilizing this state.

Also includes a fix that allows customization via the builder of a handler/serializer/deserializer which is also registered as a service.